### PR TITLE
add `is_post_policy` to the `TimePrefix` state hash

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -93,9 +93,9 @@ pub fn decode_updates(message: RouteMonitoring, header: UpdateHeader) -> Option<
     }
 }
 
-pub fn create_withdraw_update(prefix: NetworkPrefix, timestamp: DateTime<Utc>) -> Update {
+pub fn synthesize_withdraw_update(prefix: NetworkPrefix, timestamp: DateTime<Utc>) -> Update {
     Update {
-        prefix: prefix,
+        prefix,
         announced: false,
         origin: Origin::INCOMPLETE,
         path: None,


### PR DESCRIPTION
This way we will have independent updates based on the `is_post_policy` value (two "streams" as the RFC says)