### PR TITLE
Wait for the socket stream to be readable

### DIFF
--- a/risotto/src/bmp.rs
+++ b/risotto/src/bmp.rs
@@ -23,6 +23,9 @@ pub async fn handle<T: StateStore>(
     debug!("[{}]:{} - session established", router_addr, router_port);
 
     loop {
+        // Wait for the stream to be readable
+        stream.readable().await?;
+
         // Get minimal packet length to get how many bytes to remove from the socket
         let mut common_header = [0; 6];
         let n_bytes_peeked = stream.peek(&mut common_header).await?;


### PR DESCRIPTION
Attempt to reduce CPU usage by waiting the socket to be readable, avoiding a busy loop.