### PR TITLE
Update bgpkit-parser dependency to version 0.12.0

### DIFF
--- a/risotto-lib/Cargo.toml
+++ b/risotto-lib/Cargo.toml
@@ -13,7 +13,7 @@ exclude.workspace = true
 
 [dependencies]
 anyhow = "1.0.95"
-bgpkit-parser = { version = "0.11.0", features = ["serde"] }
+bgpkit-parser = { version = "0.12.0", features = ["serde"] }
 bytes = "1.9.0"
 chrono = "0.4.39"
 metrics = "0.24.2"


### PR DESCRIPTION
Version 0.12.0 includes a fix for parsing BGP Open messages that also affects the parsing of BMP's PeerUpNotification messages (which includes BGP Open messages).