### PR TITLE
chore(renovate): enable lockFileMaintenance and vulnerabilityAlerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,17 @@
     "config:recommended"
   ],
 
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["before 6am on monday"]
+  },
+
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  },
+
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "digest"],


### PR DESCRIPTION
## Summary
- Enables `lockFileMaintenance` (weekly schedule) so Renovate sweeps transitive Cargo.lock bumps — currently missed because `config:recommended` only updates direct deps declared in `Cargo.toml`.
- Makes `vulnerabilityAlerts` explicit with a `security` label for easier triage. (It's already on via `config:recommended`, but this surfaces it in the config for clarity.)

## Motivation
3 open Dependabot alerts on this repo (`rand`, `rustls-webpki` × 2) are all transitive-only. They would not be picked up by Renovate today because no direct-dep bump in `Cargo.toml` pulls them in. `lockFileMaintenance` periodically runs `cargo update` and opens a PR, closing these gaps.

## Test plan
- [ ] Renovate picks up the config on next run (check `app/renovate`'s dashboard issue)
- [ ] Within one week, a `Lock file maintenance` PR is opened
- [ ] Current Dependabot alerts (#20, #21, #22) auto-close after that PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)